### PR TITLE
Lowercase the search token for subscription ids, and handle ambiguous or empty results

### DIFF
--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -11,7 +11,7 @@ from azure.cli.core import get_default_cli
 from .envvars import EnvVars
 
 def get_query_argument_for_id_and_name(token):
-    return "[?starts_with(@.id,'{0}') || starts_with(@.name,'{1}')]".format(token.lower(), token)
+    return "[?starts_with(@.id,'{0}') || contains(@.name,'{1}')]".format(token.lower(), token)
 
 class AzureCli:
     def __init__(self,  output, envvars, cli=get_default_cli()):
@@ -161,7 +161,7 @@ class AzureCli:
         with output_io_cls() as io:
             query = get_query_argument_for_id_and_name(token)
             result = self.invoke_az_cli_outproc(["account", "list", "--query", query],
-                                                "Could not find a subscription that starts with '{0}'".format(token), io)
+                                                "Could not find a subscription for which the id starts with or name contains '{0}'".format(token), io)
 
             if result:
                 out_string = io.getvalue()
@@ -171,9 +171,9 @@ class AzureCli:
                     if len(data) == 1:
                         return data[0]["id"]
                     elif len(data) > 1:
-                        self.output.error("Found multiple subscriptions that start with '{0}'. Please enter more characters to further refine your selection.".format(token))
+                        self.output.error("Found multiple subscriptions for which the ids start with or names contain '{0}'. Please enter more characters to further refine your selection.".format(token))
                     else:
-                        self.output.error("Could not find a subscription that starts with '{0}'.".format(token))
+                        self.output.error("Could not find a subscription for which the id starts with or name contains '{0}'.".format(token))
 
         return ''
 

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -10,6 +10,8 @@ output_io_cls = StringIO
 from azure.cli.core import get_default_cli
 from .envvars import EnvVars
 
+def get_query_argument_for_id_and_name(token):
+    return "[?starts_with(@.id,'{0}') || starts_with(@.name,'{1}')]".format(token.lower(), token)
 
 class AzureCli:
     def __init__(self,  output, envvars, cli=get_default_cli()):
@@ -157,7 +159,8 @@ class AzureCli:
 
     def get_subscription_id_starts_with(self, token):
         with output_io_cls() as io:
-            result = self.invoke_az_cli_outproc(["account", "list", "--query", "[?starts_with(@.id,'{0}') || starts_with(@.name,'{1}')] | [0]".format(token.lower(), token)],
+            query = get_query_argument_for_id_and_name(token)
+            result = self.invoke_az_cli_outproc(["account", "list", "--query", query],
                                                 "Could not find a subscription that starts with '{0}'".format(token), io)
 
             if result:

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -157,7 +157,7 @@ class AzureCli:
 
     def get_subscription_id_starts_with(self, token):
         with output_io_cls() as io:
-            result = self.invoke_az_cli_outproc(["account", "list", "--query", "[?starts_with(@.id,'{0}') || starts_with(@.name,'{0}')] | [0]".format(token)],
+            result = self.invoke_az_cli_outproc(["account", "list", "--query", "[?starts_with(@.id,'{0}') || starts_with(@.name,'{1}')] | [0]".format(token.lower(), token)],
                                                 "Could not find a subscription that starts with '{0}'".format(token), io)
             if result:
                 out_string = io.getvalue()

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -168,9 +168,9 @@ class AzureCli:
                     if len(data) == 1:
                         return data[0]["id"]
                     elif len(data) > 1:
-                        self.output.error("Found multiple subscriptions that start with '{0}'".format(token))
+                        self.output.error("Found multiple subscriptions that start with '{0}'. Please enter more characters to further refine your selection.".format(token))
                     else:
-                        self.output.error("Could not find a subscription that starts with '{0}'".format(token))
+                        self.output.error("Could not find a subscription that starts with '{0}'.".format(token))
 
         return ''
 

--- a/tests/test_azurecli.py
+++ b/tests/test_azurecli.py
@@ -1,0 +1,27 @@
+import pytest
+from iotedgedev.azurecli import get_query_argument_for_id_and_name
+
+def get_terms(query):
+    # These tests are all asserting that the query contains two terms enclosed in 
+    # [?], separated by || 
+    # They don't care about the order. Tests will fail if the square brackets and || 
+    # contract is violated, but we'd want them to fail in that case.
+    return query[2:len(query)-1].split(" || ")
+
+def test_lowercase_token_should_be_lowercase_for_name_and_id():
+    token = "abc123"
+    query = get_query_argument_for_id_and_name(token)
+    terms = get_terms(query)
+
+    assert len(terms) == 2
+    assert "starts_with(@.id,'abc123')" in terms 
+    assert "starts_with(@.name,'abc123')" in terms
+
+def test_mixedcase_token_should_be_lowercase_for_id_but_unmodified_for_name():
+    token = "AbC123"
+    query = get_query_argument_for_id_and_name(token)
+    terms = get_terms(query)
+
+    assert len(terms) == 2
+    assert "starts_with(@.id,'abc123')" in terms 
+    assert "starts_with(@.name,'AbC123')" in terms

--- a/tests/test_azurecli.py
+++ b/tests/test_azurecli.py
@@ -15,7 +15,7 @@ def test_lowercase_token_should_be_lowercase_for_name_and_id():
 
     assert len(terms) == 2
     assert "starts_with(@.id,'abc123')" in terms 
-    assert "starts_with(@.name,'abc123')" in terms
+    assert "contains(@.name,'abc123')" in terms
 
 def test_mixedcase_token_should_be_lowercase_for_id_but_unmodified_for_name():
     token = "AbC123"
@@ -24,4 +24,4 @@ def test_mixedcase_token_should_be_lowercase_for_id_but_unmodified_for_name():
 
     assert len(terms) == 2
     assert "starts_with(@.id,'abc123')" in terms 
-    assert "starts_with(@.name,'AbC123')" in terms
+    assert "contains(@.name,'AbC123')" in terms


### PR DESCRIPTION
- When searching for the subscription id, lowercase the search token
- When multiple subscriptions match, do not assume the first was desired
