### PR TITLE
Add an underscore after additional registry environment key prefixes

### DIFF
--- a/.env.tmp
+++ b/.env.tmp
@@ -9,22 +9,23 @@ DEVICE_CONNECTION_STRING=""
 #
 # CONTAINER REGISTRY
 #
-    # Settings for your container registry, set CONTAINER_REGISTRY_SERVER to the following as the default registry:
-    # Local Registry: "localhost:5000" - USERNAME/PASSWORD not required.
-    # Azure Container Registry: "jong.azurecr.io", Also set USERNAME/PASSWORD
-    # Docker Hub: "jongallant" - Your Docker hub username. Enter your Docker hub username into the CONTAINER_REGISTRY_USERNAME setting. Also set the PASSWORD.
+    # Settings for your container default registry.
+    # Set CONTAINER_REGISTRY_SERVER to the following:
+    # - Local Registry: "localhost:5000" - USERNAME/PASSWORD not required.
+    # - Azure Container Registry: "jong.azurecr.io", Also set USERNAME/PASSWORD
+    # - Docker Hub: "jongallant" - Your Docker hub username. Enter your Docker hub username into the CONTAINER_REGISTRY_USERNAME setting. Also set the PASSWORD.
 
 CONTAINER_REGISTRY_SERVER="localhost:5000"
 CONTAINER_REGISTRY_USERNAME=""
 CONTAINER_REGISTRY_PASSWORD=""
 
-    # To specify additional container registries ensure the prefix is CONTAINER_REGISTRY_SERVER, CONTAINER_REGISTRY_USERNAME, CONTAINER_REGISTRY_PASSWORD
+    # To specify additional container registries ensure the prefix is CONTAINER_REGISTRY_SERVER_, CONTAINER_REGISTRY_USERNAME_, CONTAINER_REGISTRY_PASSWORD_
     # And the token following the prefix uniquely associates the SERVER/USERNAME/PASSWORD
     # Token can be any string of alphanumeric characters
 
-# CONTAINER_REGISTRY_SERVER2=""
-# CONTAINER_REGISTRY_USERNAME2=""
-# CONTAINER_REGISTRY_PASSWORD2=""
+# CONTAINER_REGISTRY_SERVER_2=""
+# CONTAINER_REGISTRY_USERNAME_2=""
+# CONTAINER_REGISTRY_PASSWORD_2=""
 
 #
 # HOST

--- a/.env.tmp
+++ b/.env.tmp
@@ -9,9 +9,9 @@ DEVICE_CONNECTION_STRING=""
 #
 # CONTAINER REGISTRY
 #
-    # Settings for your container default registry.
+    # Settings for your default container registry.
     # Set CONTAINER_REGISTRY_SERVER to the following:
-    # - Local Registry: "localhost:5000" - USERNAME/PASSWORD not required.
+    # - Local Registry: "localhost:5000" - USERNAME/PASSWORD not required (Windows container not supported)
     # - Azure Container Registry: "jong.azurecr.io", Also set USERNAME/PASSWORD
     # - Docker Hub: "jongallant" - Your Docker hub username. Enter your Docker hub username into the CONTAINER_REGISTRY_USERNAME setting. Also set the PASSWORD.
 

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -278,10 +278,12 @@ class AzureCli:
         self.output.status(f("Deploying '{config}' to '{device_id}'..."))
         config = os.path.join(os.getcwd(), config)
 
-        return self.invoke_az_cli_outproc(["iot", "edge", "set-modules", "-d", device_id, "-n", hub_name, "-k", config, "-l", connection_string], error_message=f("Failed to deploy '{config}' to '{device_id}'..."), suppress_output=True)
+        return self.invoke_az_cli_outproc(["iot", "edge", "set-modules", "-d", device_id, "-n", hub_name, "-k", config, "-l", connection_string],
+                                          error_message=f("Failed to deploy '{config}' to '{device_id}'..."), suppress_output=True)
 
     def monitor_events(self, device_id, connection_string, hub_name, timeout=300):
-        return self.invoke_az_cli_outproc(["iot", "hub", "monitor-events", "-d", device_id, "-n", hub_name, "-l", connection_string, '-t', str(timeout), '-y'], error_message=f("Failed to start monitoring events."), suppress_output=False, timeout=timeout)
+        return self.invoke_az_cli_outproc(["iot", "hub", "monitor-events", "-d", device_id, "-n", hub_name, "-l", connection_string, '-t', str(timeout), '-y'],
+                                          error_message=f("Failed to start monitoring events."), suppress_output=False, timeout=timeout)
 
     def get_free_iothub(self):
         with output_io_cls() as io:
@@ -312,7 +314,8 @@ class AzureCli:
         self.output.header("IOT HUB")
         self.output.status(f("Retrieving IoT Hubs in '{resource_group}'..."))
 
-        return self.invoke_az_cli_outproc(["iot", "hub", "list", "--resource-group", resource_group, "--query", "[].{\"IoT Hub\":name}", "--out", "table"], f("Could not list the IoT Hubs in {resource_group}."))
+        return self.invoke_az_cli_outproc(["iot", "hub", "list", "--resource-group", resource_group, "--query", "[].{\"IoT Hub\":name}", "--out", "table"],
+                                          f("Could not list the IoT Hubs in {resource_group}."))
 
     def iothub_exists(self, value, resource_group):
         self.output.status(

--- a/iotedgedev/dockercls.py
+++ b/iotedgedev/dockercls.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 import zipfile
 
 import docker

--- a/iotedgedev/envvars.py
+++ b/iotedgedev/envvars.py
@@ -256,9 +256,12 @@ class EnvVars:
         add_key_prefix_length = len(add_key_prefix)
 
         if env_key.startswith(default_key_prefix):
-            token = ''
-            if env_key != default_key_prefix and env_key[add_key_prefix_length - 1] == '_':
+            if env_key == default_key_prefix:
+                token = ''
+            elif env_key.startswith(add_key_prefix):
                 token = env_key[add_key_prefix_length:]
+            else:
+                return
 
             if token not in self.CONTAINER_REGISTRY_MAP:
                 self.CONTAINER_REGISTRY_MAP[token] = ContainerRegistry('', '', '')

--- a/iotedgedev/envvars.py
+++ b/iotedgedev/envvars.py
@@ -261,5 +261,5 @@ class EnvVars:
                 token = env_key[add_key_prefix_length:]
 
             if token not in self.CONTAINER_REGISTRY_MAP:
-                self.CONTAINER_REGISTRY_MAP[token] = ContainerRegistry(None, None, None)
+                self.CONTAINER_REGISTRY_MAP[token] = ContainerRegistry('', '', '')
             setattr(self.CONTAINER_REGISTRY_MAP[token], subkey.lower(), self.get_envvar(env_key))

--- a/iotedgedev/modules.py
+++ b/iotedgedev/modules.py
@@ -152,7 +152,7 @@ class Modules:
                             registry_key = key
                             break
                     if registry_key is None:
-                        self.output.error("Could not find registry server with name {0}. Please make sure your envvar is set.".format(tag.split('/')[0].lower()))
+                        raise ValueError("Could not find registry server with name {0}. Please make sure your envvar is set.".format(tag.split('/')[0].lower()))
                     self.output.info("module json reading {0}".format(tag))
 
                     response = docker.docker_client.images.push(repository=tag, stream=True, auth_config={

--- a/iotedgedev/template/.env.tmp
+++ b/iotedgedev/template/.env.tmp
@@ -9,22 +9,23 @@ DEVICE_CONNECTION_STRING=""
 #
 # CONTAINER REGISTRY
 #
-    # Settings for your container registry, set CONTAINER_REGISTRY_SERVER to the following as the default registry:
-    # Local Registry: "localhost:5000" - USERNAME/PASSWORD not required.
-    # Azure Container Registry: "jong.azurecr.io", Also set USERNAME/PASSWORD
-    # Docker Hub: "jongallant" - Your Docker hub username. Enter your Docker hub username into the CONTAINER_REGISTRY_USERNAME setting. Also set the PASSWORD.
+    # Settings for your container default registry.
+    # Set CONTAINER_REGISTRY_SERVER to the following:
+    # - Local Registry: "localhost:5000" - USERNAME/PASSWORD not required.
+    # - Azure Container Registry: "jong.azurecr.io", Also set USERNAME/PASSWORD
+    # - Docker Hub: "jongallant" - Your Docker hub username. Enter your Docker hub username into the CONTAINER_REGISTRY_USERNAME setting. Also set the PASSWORD.
 
 CONTAINER_REGISTRY_SERVER="localhost:5000"
 CONTAINER_REGISTRY_USERNAME=""
 CONTAINER_REGISTRY_PASSWORD=""
 
-    # To specify additional container registries ensure the prefix is CONTAINER_REGISTRY_SERVER, CONTAINER_REGISTRY_USERNAME, CONTAINER_REGISTRY_PASSWORD
+    # To specify additional container registries ensure the prefix is CONTAINER_REGISTRY_SERVER_, CONTAINER_REGISTRY_USERNAME_, CONTAINER_REGISTRY_PASSWORD_
     # And the token following the prefix uniquely associates the SERVER/USERNAME/PASSWORD
     # Token can be any string of alphanumeric characters
 
-# CONTAINER_REGISTRY_SERVER2=""
-# CONTAINER_REGISTRY_USERNAME2=""
-# CONTAINER_REGISTRY_PASSWORD2=""
+# CONTAINER_REGISTRY_SERVER_2=""
+# CONTAINER_REGISTRY_USERNAME_2=""
+# CONTAINER_REGISTRY_PASSWORD_2=""
 
 #
 # HOST

--- a/iotedgedev/template/.env.tmp
+++ b/iotedgedev/template/.env.tmp
@@ -9,9 +9,9 @@ DEVICE_CONNECTION_STRING=""
 #
 # CONTAINER REGISTRY
 #
-    # Settings for your container default registry.
+    # Settings for your default container registry.
     # Set CONTAINER_REGISTRY_SERVER to the following:
-    # - Local Registry: "localhost:5000" - USERNAME/PASSWORD not required.
+    # - Local Registry: "localhost:5000" - USERNAME/PASSWORD not required (Windows container not supported)
     # - Azure Container Registry: "jong.azurecr.io", Also set USERNAME/PASSWORD
     # - Docker Hub: "jongallant" - Your Docker hub username. Enter your Docker hub username into the CONTAINER_REGISTRY_USERNAME setting. Also set the PASSWORD.
 

--- a/tests/test_envvars.py
+++ b/tests/test_envvars.py
@@ -182,27 +182,24 @@ def test_container_registry_server_key_missing_sys_exit():
     output = Output()
     envvars = EnvVars(output)
     with pytest.raises(ValueError):
-        envvars.get_envvar("CONTAINER_REGISTRY_SERVERUNITTEST", required=True)
+        envvars.get_envvar("CONTAINER_REGISTRY_SERVER_UNITTEST", required=True)
 
 
 @pytest.fixture
 def setup_test_env(request):
     output = Output()
     envvars = EnvVars(output)
-    envvars.set_envvar("CONTAINER_REGISTRY_SERVERUNITTEST", '')
+    envvars.set_envvar("CONTAINER_REGISTRY_SERVER_UNITTEST", 'unittest.azurecr.io')
+    envvars.set_envvar("CONTAINER_REGISTRY_USERNAME_UNITTEST", 'username')
+    envvars.set_envvar("CONTAINER_REGISTRY_PASSWORD_UNITTEST", 'password')
 
     def clean():
-        os.environ.pop("CONTAINER_REGISTRY_SERVERUNITTEST")
+        os.environ.pop("CONTAINER_REGISTRY_SERVER_UNITTEST")
+        os.environ.pop("CONTAINER_REGISTRY_USERNAME_UNITTEST")
+        os.environ.pop("CONTAINER_REGISTRY_PASSWORD_UNITTEST")
     request.addfinalizer(clean)
 
     return
-
-
-def test_container_registry_server_value_missing_sys_exit(setup_test_env):
-    output = Output()
-    envvars = EnvVars(output)
-    with pytest.raises(ValueError):
-        envvars.get_envvar("CONTAINER_REGISTRY_SERVERUNITTEST", required=True)
 
 
 def test_unique_container_registry_server_tokens():
@@ -259,45 +256,12 @@ def test_unique_container_registry_password_tokens():
     assert is_unique
 
 
-def test_container_registry_map_has_val():
+def test_additional_container_registry_map_has_val(setup_test_env):
     output = Output()
     envvars = EnvVars(output)
     envvars.load()
-    result = envvars.verify_envvar_has_val("CONTAINER_REGISTRY_MAP", envvars.CONTAINER_REGISTRY_MAP)
-    assert not result
-
-
-def test_additional_container_registry_server_has_val():
-    output = Output()
-    envvars = EnvVars(output)
-    envvars.load()
-    if len(envvars.CONTAINER_REGISTRY_MAP) > 1:
-        keys = envvars.CONTAINER_REGISTRY_MAP.keys()
-        for key in keys:
-            if key != '':
-                token = key
-        assert envvars.CONTAINER_REGISTRY_MAP[token].server is not None
-
-
-def test_additional_container_registry_username_has_val():
-    output = Output()
-    envvars = EnvVars(output)
-    envvars.load()
-    if len(envvars.CONTAINER_REGISTRY_MAP) > 1:
-        keys = envvars.CONTAINER_REGISTRY_MAP.keys()
-        for key in keys:
-            if key != '':
-                token = key
-        assert envvars.CONTAINER_REGISTRY_MAP[token].username is not None
-
-
-def test_additional_container_registry_password_has_val():
-    output = Output()
-    envvars = EnvVars(output)
-    envvars.load()
-    if len(envvars.CONTAINER_REGISTRY_MAP) > 1:
-        keys = envvars.CONTAINER_REGISTRY_MAP.keys()
-        for key in keys:
-            if key != '':
-                token = key
-        assert envvars.CONTAINER_REGISTRY_MAP[token].password is not None
+    assert len(envvars.CONTAINER_REGISTRY_MAP) == 2
+    assert 'UNITTEST' in envvars.CONTAINER_REGISTRY_MAP.keys()
+    assert envvars.CONTAINER_REGISTRY_MAP['UNITTEST'].server == 'unittest.azurecr.io'
+    assert envvars.CONTAINER_REGISTRY_MAP['UNITTEST'].username == 'username'
+    assert envvars.CONTAINER_REGISTRY_MAP['UNITTEST'].password == 'password'


### PR DESCRIPTION
The benefit of adding the underscore:
1. Clarity: `CONTAINER_REGISTRY_SERVER_PRODUCTION` vs. `CONTAINER_REGISTRY_SERVERPRODUCTION`
2. Compatibility with the .env file generated by the VS Code extension: https://github.com/Microsoft/vscode-azure-iot-edge/blob/master/src/edge/edgeManager.ts#L501-L502

Also fix #265 