### PR TITLE
Change stream handling to background threads to avoid blocking

### DIFF
--- a/iotedgedev/output.py
+++ b/iotedgedev/output.py
@@ -1,4 +1,5 @@
 import click
+import six
 
 
 class Output:
@@ -48,7 +49,7 @@ class Output:
         try:
             click.secho(text, fg=color, dim=dim)
         except Exception:
-            print(text)
+            six.print_(text)
 
     def confirm(self, text, default=False, abort=True):
         return click.confirm(text, default=default, abort=abort)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -111,10 +111,12 @@ def test_monitor(capfd):
     print(err)
     print(result.output)
 
+    # Assert output from simulator
+    sim_match = 'timeCreated'
+
     if not PY35:
         assert 'Monitoring events from device' in out
+        assert sim_match in out
     else:
         assert not err
-
-    # TODO: This assertion seems out of place
-    # assert 'timeCreated' in out
+        assert sim_match in result.output


### PR DESCRIPTION
This PR combined with PR [#301](https://github.com/Azure/iotedgedev/pull/301) should give us expected behavior for Py 3.5+ monitoring.

Includes:
* ctrl-c interrupt happens fast
* can terminate with or without incoming data

Test Note: The 'tests/test_simulator.py' assertion uncommented. This assertion works when invoking pytest normally, but when running via Tox, the same assertion fails. Not sure why yet, but I suspect it has to do with some stream clobbering.