### PR TITLE
Handle new line in docker output correctly

### DIFF
--- a/iotedgedev/dockercls.py
+++ b/iotedgedev/dockercls.py
@@ -236,7 +236,7 @@ class Docker:
         for json_ in docker.utils.json_stream.json_stream(response):
             for key in json_:
                 if key in {"status", "stream"} and isinstance(json_[key], six.string_types):
-                    self.output.procout(json_[key].rstrip())
+                    self.output.procout(json_[key], nl=False)
 
             # Docker SDK won't throw exceptions for some failures.
             # We have to check the response ourselves.

--- a/iotedgedev/output.py
+++ b/iotedgedev/output.py
@@ -39,15 +39,15 @@ class Output:
             self.info(text.upper())
             self.line()
 
-    def procout(self, text):
-        self.echo(text, dim=True)
+    def procout(self, text, nl=True):
+        self.echo(text, dim=True, nl=nl)
 
     def line(self):
         self.echo(text="")
 
-    def echo(self, text, color="", dim=False):
+    def echo(self, text, color="", dim=False, nl=True):
         try:
-            click.secho(text, fg=color, dim=dim)
+            click.secho(text, fg=color, dim=dim, nl=nl)
         except Exception:
             six.print_(text)
 


### PR DESCRIPTION
For some tools such as Maven, output are piped on a character basis instead of line.

Known issue: ANSI color codes are not correctly shown as ANSI color control sequences and codes are piped separately from docker API output:
![image](https://user-images.githubusercontent.com/716650/46854756-787ed780-ce34-11e8-8c4a-345612803e74.png)
