### PR TITLE
Append new lines to docker push status output

### DIFF
--- a/iotedgedev/dockercls.py
+++ b/iotedgedev/dockercls.py
@@ -235,8 +235,10 @@ class Docker:
     def process_api_response(self, response):
         for json_ in docker.utils.json_stream.json_stream(response):
             for key in json_:
-                if key in {"status", "stream"} and isinstance(json_[key], six.string_types):
+                if key == "stream" and isinstance(json_[key], six.string_types):
                     self.output.procout(json_[key], nl=False)
+                if key == "status" and isinstance(json_[key], six.string_types):
+                    self.output.procout(json_[key])
 
             # Docker SDK won't throw exceptions for some failures.
             # We have to check the response ourselves.


### PR DESCRIPTION
Docker API streams output in JSON format. For `docker build`, we care about the `stream` property in the JSON, while for `docker push`, we care about the `status` property. The `stream` property comes with newlines, while the `status` property not. See Docker CLI's reference handling of [`stream`](https://github.com/docker/cli/blob/master/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go#L237-L238) and [`status`](https://github.com/docker/cli/blob/master/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go#L233-L234)

Current output of `iotedgedev build`:
![image](https://user-images.githubusercontent.com/716650/47419559-1072ae80-d7af-11e8-86ce-9fbf9b5ed4e6.png)

`iotedgedev push --no-build`:
![image](https://user-images.githubusercontent.com/716650/47419624-2bddb980-d7af-11e8-82bc-62d99eb8a7ff.png)
