### PR TITLE
Migrate AZDO pool to Hosted Ubuntu 1604

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -3,12 +3,13 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/vsts/pipelines/languages/python
 
-phases:
+jobs:
 
-- phase: 'Test'
-  queue:
-    name: 'Hosted Linux Preview'
-    parallel: 4
+- job: 'Test'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    maxParallel: 4
     matrix:
       Python27:
         python.version: '2.7'


### PR DESCRIPTION
Hosted Linux Preview pool is being deprecated on December 1, 2018.