### PR TITLE
Fix host.docker.internal not available in linux docker issue

### DIFF
--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     iproute2 \
+    iputils-ping \
     systemd  && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > ./microsoft-prod.list && \

--- a/docker/runtime/rund.sh
+++ b/docker/runtime/rund.sh
@@ -3,6 +3,10 @@
 echo '=> detecting IP'
 export IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
 export IOT_DEVICE_HOSTNAME="host.docker.internal"
+ping -q -c1 $IOT_DEVICE_HOSTNAME > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  IOT_DEVICE_HOSTNAME=$(ip route | awk '/default/ { print $3 }' | awk '!seen[$0]++')
+fi
 
 echo '=> creating config.yaml'
 cat <<EOF > /etc/iotedge/config.yaml


### PR DESCRIPTION
host.docker.internal is not available in docker for linux, use the actual ip address when host.docker.internal is unavailable