### PR TITLE
Fixed issue with 'cs' keyerror

### DIFF
--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -452,7 +452,11 @@ class AzureCli:
             if result:
                 out_string = io.getvalue()
                 data = json.loads(out_string)
-                return data["connectionString"]
+                if "cs" in data:
+                    return data["cs"]
+                else:
+                    return data["connectionString"]
+
         return ''
 
     def edge_device_exists(self, value, iothub, resource_group):
@@ -495,6 +499,9 @@ class AzureCli:
             if result:
                 out_string = io.getvalue()
                 data = json.loads(out_string)
-                return data["connectionString"]
+                if "cs" in data:
+                    return data["cs"]
+                else:
+                    return data["connectionString"]
 
         return ''

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -452,7 +452,7 @@ class AzureCli:
             if result:
                 out_string = io.getvalue()
                 data = json.loads(out_string)
-                return data["cs"]
+                return data["connectionString"]
         return ''
 
     def edge_device_exists(self, value, iothub, resource_group):
@@ -495,6 +495,6 @@ class AzureCli:
             if result:
                 out_string = io.getvalue()
                 data = json.loads(out_string)
-                return data["cs"]
+                return data["connectionString"]
 
         return ''


### PR DESCRIPTION
There was a key error here, and now it is using the full-blown "connectionString" as the key.

It is related to this issue: https://github.com/Azure/iotedgedev/issues/387

If 'cs' is being used by older versions of the Azure CLI, for example, there could be room here to check to see if the key exists before trying to grab it.