### PR TITLE
Fix CI

### DIFF
--- a/vsts_ci/.vsts-ci.yml
+++ b/vsts_ci/.vsts-ci.yml
@@ -6,7 +6,19 @@
 jobs:
   - job: Windows
     pool:
-      vmImage: win1803
+      vmImage: windows-2019
+    strategy:
+      matrix:
+        Python27:
+          python.version: "2.7"
+          TOXENV: "py27"
+        Python36:
+          python.version: "3.6"
+          TOXENV: "py36"
+        Python37:
+          python.version: "3.7"
+          TOXENV: "py37"
+      maxParallel: 1
     steps:
       - template: win32/continuous-build-win32.yml
 

--- a/vsts_ci/darwin/continuous-build-darwin.yml
+++ b/vsts_ci/darwin/continuous-build-darwin.yml
@@ -53,6 +53,7 @@ steps:
       eval $(docker-machine env default)
       brew services start docker-machine
       brew install docker-compose
+      sleep 10
       docker version
       sudo -E tox -e "$(TOXENV)"
     displayName: "Install docker and run tests against iotedgedev source code with tox"

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -15,7 +15,6 @@ steps:
 
   - pwsh: |
       az extension add --name azure-cli-iot-ext
-      az --version
     displayName: "Install Azure CLI IoT Extension"
 
   - pwsh: |

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -1,7 +1,6 @@
 steps:
-  - powershell: |
+  - pwsh: |
       ((Get-Content -path "$(BUILD.REPOSITORY.LOCALPATH)\.env.tmp" -Raw) -replace 'IOTHUB_CONNECTION_STRING=".*"','IOTHUB_CONNECTION_STRING="$(IOTHUB_CONNECTION_STRING)"' -replace 'DEVICE_CONNECTION_STRING=".*"','DEVICE_CONNECTION_STRING="$(DEVICE_CONNECTION_STRING)"' -replace 'CONTAINER_REGISTRY_SERVER=".*"','CONTAINER_REGISTRY_SERVER="$(CONTAINER_REGISTRY_SERVER)"' -replace 'CONTAINER_REGISTRY_USERNAME=".*"','CONTAINER_REGISTRY_USERNAME="$(CONTAINER_REGISTRY_USERNAME)"' -replace 'CONTAINER_REGISTRY_PASSWORD=".*"','CONTAINER_REGISTRY_PASSWORD="$(CONTAINER_REGISTRY_PASSWORD)"') | Set-Content -Path "$(BUILD.REPOSITORY.LOCALPATH)\.env.tmp"
-    pwsh: true
     displayName: "Update .env.tmp file"
 
   - task: UsePythonVersion@0
@@ -10,18 +9,16 @@ steps:
       addToPath: true
       architecture: "x64"
 
-  - powershell: |
+  - pwsh: |
       npm i -g iothub-explorer yo generator-azure-iot-edge-module
-    pwsh: true
     displayName: "Install IoT Hub explorer, Yeoman and Azure IoT Edge Node.js module generator packages"
 
-  - powershell: |
+  - pwsh: |
       az extension add --name azure-cli-iot-ext
       az --version
-    pwsh: true
     displayName: "Install Azure CLI IoT Extension"
 
-  - powershell: |
+  - pwsh: |
       pip install tox
       tox -e "$(TOXENV)"
     displayName: "Run tests against iotedgedev source code"

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -1,45 +1,27 @@
 steps:
   - powershell: |
       ((Get-Content -path "$(BUILD.REPOSITORY.LOCALPATH)\.env.tmp" -Raw) -replace 'IOTHUB_CONNECTION_STRING=".*"','IOTHUB_CONNECTION_STRING="$(IOTHUB_CONNECTION_STRING)"' -replace 'DEVICE_CONNECTION_STRING=".*"','DEVICE_CONNECTION_STRING="$(DEVICE_CONNECTION_STRING)"' -replace 'CONTAINER_REGISTRY_SERVER=".*"','CONTAINER_REGISTRY_SERVER="$(CONTAINER_REGISTRY_SERVER)"' -replace 'CONTAINER_REGISTRY_USERNAME=".*"','CONTAINER_REGISTRY_USERNAME="$(CONTAINER_REGISTRY_USERNAME)"' -replace 'CONTAINER_REGISTRY_PASSWORD=".*"','CONTAINER_REGISTRY_PASSWORD="$(CONTAINER_REGISTRY_PASSWORD)"') | Set-Content -Path "$(BUILD.REPOSITORY.LOCALPATH)\.env.tmp"
+    pwsh: true
     displayName: "Update .env.tmp file"
 
-  - task: DotNetCoreInstaller@0
+  - task: UsePythonVersion@0
     inputs:
-      packageType: 'sdk'
-      version: '2.2.103'
-    displayName: "Install .NET Core SDK"
-
-  - powershell: |
-      choco install jdk8 --version 8.0.211
-      $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0_211"
-      choco install maven
-      mvn -v
-    displayName: "Install JDK and Maven"
-
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '10.x'
-    displayName: "Install Node.js"
+      versionSpec: "$(python.version)"
+      addToPath: true
+      architecture: "x64"
 
   - powershell: |
       npm i -g iothub-explorer yo generator-azure-iot-edge-module
+    pwsh: true
     displayName: "Install IoT Hub explorer, Yeoman and Azure IoT Edge Node.js module generator packages"
 
   - powershell: |
-      choco install azure-cli
-      $env:Path += ";C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin"
       az extension add --name azure-cli-iot-ext
       az --version
-    displayName: "Install Azure CLI And Azure CLI IoT Extension"
+    pwsh: true
+    displayName: "Install Azure CLI IoT Extension"
 
   - powershell: |
-      $env:Path += ";C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin"
-      $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0_211"
-      choco install python2
-      choco install python --version 3.6.6
-      choco install python --version 3.7.1
-      $env:Path += ";C:\Python37;C:\Python37\Scripts"
-      python -m pip install --upgrade pip
       pip install tox
-      tox
+      tox -e "$(TOXENV)"
     displayName: "Run tests against iotedgedev source code"

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -10,8 +10,8 @@ steps:
     displayName: "Install .NET Core SDK"
 
   - powershell: |
-      choco install jdk8 --version 8.0.201
-      $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0_201"
+      choco install jdk8 --version 8.0.211
+      $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0_211"
       choco install maven
       mvn -v
     displayName: "Install JDK and Maven"
@@ -34,7 +34,7 @@ steps:
 
   - powershell: |
       $env:Path += ";C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin"
-      $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0_201"
+      $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0_211"
       choco install python2
       choco install python --version 3.6.6
       choco install python --version 3.7.1


### PR DESCRIPTION
1. Change Windows agent so we don't need to install most dependencies by ourselves, which breaks current CI
2. Wait sometime in Mac OS tests to resolve random docker not started failure
3. Break windows tests into multiple matrix