### PR TITLE
allow non module project 

### DIFF
--- a/iotedgedev/module.py
+++ b/iotedgedev/module.py
@@ -13,7 +13,6 @@ class Module(object):
         self.utility = utility
         self.module_dir = module_dir
         self.module_json_file = os.path.join(self.module_dir, "module.json")
-        self.module_language = "csharp"
         self.file_json_content = None
         self.load_module_json()
 
@@ -21,17 +20,12 @@ class Module(object):
         if os.path.exists(self.module_json_file):
             try:
                 self.file_json_content = json.loads(Utility.get_file_contents(self.module_json_file, expandvars=True))
-                self.module_language = self.file_json_content.get("language").lower()
             except KeyError as e:
                 raise KeyError("Error parsing {0} from module.json file : {1}".format(str(e), self.module_json_file))
             except IOError:
                 raise IOError("Error loading module.json file : {0}".format(self.module_json_file))
         else:
             raise FileNotFoundError("No module.json file found. module.json file is required in the root of your module folder")
-
-    @property
-    def language(self):
-        return self.module_language
 
     @property
     def platforms(self):

--- a/iotedgedev/modules.py
+++ b/iotedgedev/modules.py
@@ -113,6 +113,7 @@ class Modules:
             deployment_manifest_debug = DeploymentManifest(self.envvars, self.output, self.utility, self.envvars.DEPLOYMENT_CONFIG_DEBUG_TEMPLATE_FILE, True)
             deployment_manifest_debug.add_module_template(name, debug_create_options, True)
             deployment_manifest_debug.dump()
+            
         self._update_launch_json(name, template, group_id)
 
         self.output.footer("ADD COMPLETE")

--- a/iotedgedev/modules.py
+++ b/iotedgedev/modules.py
@@ -113,7 +113,7 @@ class Modules:
             deployment_manifest_debug = DeploymentManifest(self.envvars, self.output, self.utility, self.envvars.DEPLOYMENT_CONFIG_DEBUG_TEMPLATE_FILE, True)
             deployment_manifest_debug.add_module_template(name, debug_create_options, True)
             deployment_manifest_debug.dump()
-
+    
         self._update_launch_json(name, template, group_id)
 
         self.output.footer("ADD COMPLETE")
@@ -145,8 +145,11 @@ class Modules:
         modules_path = os.path.join(template_file_folder, self.envvars.MODULES_PATH)
         if os.path.isdir(modules_path):
             for folder_name in os.listdir(modules_path):
-                module = Module(self.envvars, self.utility, os.path.join(modules_path, folder_name))
-                self._update_module_maps("MODULES.{0}".format(folder_name), module, placeholder_tag_map, tag_build_profile_map, default_platform)
+                try:
+                    module = Module(self.envvars, self.utility, os.path.join(modules_path, folder_name))
+                    self._update_module_maps("MODULES.{0}".format(folder_name), module, placeholder_tag_map, tag_build_profile_map, default_platform)
+                except FileNotFoundError:
+                    pass
 
         # get image tags for ${MODULEDIR<relative path>.xxx} placeholder
         user_modules = deployment_manifest.get_user_modules()
@@ -301,7 +304,7 @@ class Modules:
             launch_json_content = Utility.get_file_contents(launch_json_file)
             for key, value in replacements.items():
                 launch_json_content = launch_json_content.replace(key, value)
-            launch_json = commentjson.loads(launch_json_content)
+            launch_json = commentjson.loads(launch_json_content.encode('ascii'))
             if is_function and launch_json is not None and "configurations" in launch_json:
                 # for Function modules, there shouldn't be launch config for local debug
                 launch_json["configurations"] = list(filter(lambda x: x["request"] != "launch", launch_json["configurations"]))

--- a/iotedgedev/modules.py
+++ b/iotedgedev/modules.py
@@ -113,7 +113,7 @@ class Modules:
             deployment_manifest_debug = DeploymentManifest(self.envvars, self.output, self.utility, self.envvars.DEPLOYMENT_CONFIG_DEBUG_TEMPLATE_FILE, True)
             deployment_manifest_debug.add_module_template(name, debug_create_options, True)
             deployment_manifest_debug.dump()
-            
+
         self._update_launch_json(name, template, group_id)
 
         self.output.footer("ADD COMPLETE")

--- a/iotedgedev/modules.py
+++ b/iotedgedev/modules.py
@@ -5,6 +5,7 @@ import sys
 from zipfile import ZipFile
 
 import commentjson
+import six
 from six import BytesIO
 from six.moves.urllib.request import urlopen
 
@@ -145,11 +146,10 @@ class Modules:
         modules_path = os.path.join(template_file_folder, self.envvars.MODULES_PATH)
         if os.path.isdir(modules_path):
             for folder_name in os.listdir(modules_path):
-                try:
-                    module = Module(self.envvars, self.utility, os.path.join(modules_path, folder_name))
+                project_folder = os.path.join(modules_path, folder_name)
+                if os.path.exists(os.path.join(project_folder, "module.json")):
+                    module = Module(self.envvars, self.utility, project_folder)
                     self._update_module_maps("MODULES.{0}".format(folder_name), module, placeholder_tag_map, tag_build_profile_map, default_platform)
-                except FileNotFoundError:
-                    pass
 
         # get image tags for ${MODULEDIR<relative path>.xxx} placeholder
         user_modules = deployment_manifest.get_user_modules()
@@ -305,7 +305,7 @@ class Modules:
             for key, value in replacements.items():
                 launch_json_content = launch_json_content.replace(key, value)
             if PY2:
-                launch_json = commentjson.loads(launch_json_content.encode('ascii'))
+                launch_json = commentjson.loads(six.binary_type(launch_json_content))
             else:
                 launch_json = commentjson.loads(launch_json_content)
             if is_function and launch_json is not None and "configurations" in launch_json:

--- a/iotedgedev/modules.py
+++ b/iotedgedev/modules.py
@@ -113,7 +113,6 @@ class Modules:
             deployment_manifest_debug = DeploymentManifest(self.envvars, self.output, self.utility, self.envvars.DEPLOYMENT_CONFIG_DEBUG_TEMPLATE_FILE, True)
             deployment_manifest_debug.add_module_template(name, debug_create_options, True)
             deployment_manifest_debug.dump()
-    
         self._update_launch_json(name, template, group_id)
 
         self.output.footer("ADD COMPLETE")
@@ -304,7 +303,10 @@ class Modules:
             launch_json_content = Utility.get_file_contents(launch_json_file)
             for key, value in replacements.items():
                 launch_json_content = launch_json_content.replace(key, value)
-            launch_json = commentjson.loads(launch_json_content.encode('ascii'))
+            if PY2:
+                launch_json = commentjson.loads(launch_json_content.encode('ascii'))
+            else:
+                launch_json = commentjson.loads(launch_json_content)
             if is_function and launch_json is not None and "configurations" in launch_json:
                 # for Function modules, there shouldn't be launch config for local debug
                 launch_json["configurations"] = list(filter(lambda x: x["request"] != "launch", launch_json["configurations"]))


### PR DESCRIPTION
Fix #396 
1. Allow non module project.
2. Remove language property which is not used in IoT Edge development now. Some customers removed this property in module.json, so reading this property may cause errors.
3. Fix unicode error in python2 due to recent commentjson update