### PR TITLE
do not use lark-parser enabled commentjson and bump version to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project since 0.82.0 will be documented in this file.
 
+## [2.0.2] - 2019-07-31
+### Changed
+- Fix errors caused by latest lark-parser release.
+
 ## [2.0.1] - 2019-07-11
 ### Changed
 - Fix build errors when some projects under modules folder have no module.json [[#396](https://github.com/Azure/iotedgedev/issues/396)]

--- a/iotedgedev/__init__.py
+++ b/iotedgedev/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'vsciet@microsoft.com'
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.1
+current_version = 2.0.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ test_requirements = [
 
 setup(
     name='iotedgedev',
-    version='2.0.1',
+    version='2.0.2',
     description='The Azure IoT Edge Dev Tool greatly simplifies the IoT Edge development process by automating many routine manual tasks, such as building, deploying, pushing modules and configuring the IoT Edge Runtime.',
     long_description='See https://github.com/azure/iotedgedev for usage instructions.',
     author='Microsoft Corporation',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
     'iotedgehubdev >= 0.8.0',
     'six',
     'applicationinsights < 0.11.8',
-    'commentjson >= 0.7.2, < 0.8.0',
+    'commentjson == 0.7.2',
     'pyyaml>=3.10,<4.3',
     'pypiwin32==219; sys_platform == "win32" and python_version < "3.6"',
     'pypiwin32==223; sys_platform == "win32" and python_version >= "3.6"'

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
     'iotedgehubdev >= 0.8.0',
     'six',
     'applicationinsights < 0.11.8',
-    'commentjson',
+    'commentjson >= 0.7.2, < 0.8.0',
     'pyyaml>=3.10,<4.3',
     'pypiwin32==219; sys_platform == "win32" and python_version < "3.6"',
     'pypiwin32==223; sys_platform == "win32" and python_version >= "3.6"'


### PR DESCRIPTION
The latest [lark-parser](https://pypi.org/project/lark-parser/) release breaks commentjson. Revert the version of commentjson to old version which doesn't use lark-parser.