### PR TITLE
Fix installation error on Azure Pipelines caused by more-itertools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project since 0.82.0 will be documented in this file.
 
+## [2.1.2] - 2020-01-14
+### Changed
+- Fix error when install on Azure Pipelines agent
+
 ## [2.1.1] - 2019-12-16
 ### Changed
 - Fix getconfig fails if template contains a placeholder that is not enclosed in quotes.[[#414](https://github.com/Azure/iotedgedev/issues/414)]

--- a/iotedgedev/__init__.py
+++ b/iotedgedev/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'vsciet@microsoft.com'
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 2.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ requirements = [
     'commentjson == 0.7.2',
     'pyyaml>=4.1,<=4.2b4',
     'pypiwin32==219; sys_platform == "win32" and python_version < "3.6"',
-    'pypiwin32==223; sys_platform == "win32" and python_version >= "3.6"'
+    'pypiwin32==223; sys_platform == "win32" and python_version >= "3.6"',
+    'more-itertools < 8.1.0'
 ]
 
 setup_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ test_requirements = [
 
 setup(
     name='iotedgedev',
-    version='2.1.1',
+    version='2.1.2',
     description='The Azure IoT Edge Dev Tool greatly simplifies the IoT Edge development process by automating many routine manual tasks, such as building, deploying, pushing modules and configuring the IoT Edge Runtime.',
     long_description='See https://github.com/azure/iotedgedev for usage instructions.',
     author='Microsoft Corporation',


### PR DESCRIPTION
Failed to install more-itertools on Azure Pipelines when installing iotedgedev.