### PR TITLE
Fix bcrypt error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ Please fork, branch and pull-request any changes you'd like to make.
 
 1. Install **[Azure CLI IoT extension](https://github.com/Azure/azure-iot-cli-extension/)**
 
-    - New Install: `az extension add --name azure-cli-iot-ext`
-    - Update Install: `az extension update --name azure-cli-iot-ext`
+    - New Install: `az extension add --name azure-iot`
+    - Update Install: `az extension update --name azure-iot`
 
 1. Install **[Node.js](https://nodejs.org/en/download/)** and the **`iothub-explorer`** package
 

--- a/docker/tool/linux/Dockerfile.base
+++ b/docker/tool/linux/Dockerfile.base
@@ -55,7 +55,7 @@ RUN useradd -m iotedgedev && \
     chown -R iotedgedev:iotedgedev /home/iotedge
 USER iotedgedev
 # Azure CLI extensions are installed per user
-RUN az extension add --name azure-cli-iot-ext && \
+RUN az extension add --name azure-iot && \
     echo 'alias python=python3' >> ~/.bashrc && \
     echo 'alias pip=pip3' >> ~/.bashrc
 ENV DEBIAN_FRONTEND teletype

--- a/docker/tool/windows/Dockerfile.base
+++ b/docker/tool/windows/Dockerfile.base
@@ -58,6 +58,6 @@ USER ContainerUser
 RUN python -m pip install --upgrade pip
 RUN pip install azure-cli cookiecutter docker-compose
 RUN npm i -g iothub-explorer yo generator-azure-iot-edge-module
-RUN az extension add --name azure-cli-iot-ext
+RUN az extension add --name azure-iot
 WORKDIR /home/iotedge
 COPY install-dev.bat /scripts/install-dev.bat

--- a/iotedgedev/cli.py
+++ b/iotedgedev/cli.py
@@ -416,13 +416,13 @@ main.add_command(monitor)
 
 
 def ensure_azure_cli_iot_ext():
-    if not azure_cli.extension_exists("azure-cli-iot-ext"):
+    if not azure_cli.extension_exists("azure-iot"):
         try:
             # Install fixed version of Azure CLI IoT extension
             azure_cli.add_extension_with_source(Constants.azure_cli_iot_ext_source_url)
         except Exception:
             # Fall back to install latest Azure CLI IoT extension when fail
-            azure_cli.add_extension("azure-cli-iot-ext")
+            azure_cli.add_extension("azure-iot")
 
 
 def validate_option(ctx, param, value):

--- a/iotedgedev/constants.py
+++ b/iotedgedev/constants.py
@@ -9,4 +9,4 @@ class Constants:
     moduledir_placeholder_pattern = r'\${MODULEDIR<(.+)>(\..+)?}'
     deployment_template_schema_url = "http://json.schemastore.org/azure-iot-edge-deployment-template-2.0"
     deployment_manifest_schema_url = "http://json.schemastore.org/azure-iot-edge-deployment-2.0"
-    azure_cli_iot_ext_source_url = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.8.6/azure_cli_iot_ext-0.8.6-py2.py3-none-any.whl"
+    azure_cli_iot_ext_source_url = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.9.0/azure_iot-0.9.0-py2.py3-none-any.whl"

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open('CHANGELOG.md') as history_file:
 
 requirements = [
     'click>=6.0',
+    'bcrypt<=3.1.7',
     'docker >= 3.7.0, < 4.0',
     'python-dotenv',
     'requests >= 2.20.0, < 2.21',


### PR DESCRIPTION
1. Specify bcrypt <= 3.1.7 to fix errors on Azure Pipelines linux agent
2. Install azure-iot instead of the old azure-cli-iot-ext extension