### PR TITLE
Load config file using read_file as readfp is being deprecated

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,23 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Python: debug test",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest",
+            "args": [
+                "-v",
+                "${workspaceFolder}/tests/test_simulator.py::test_monitor"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
             "name": "Python Module",
             "type": "python",
             "request": "launch",
             "module": "iotedgedev.cli",
             "args": [
-                "push"
+                "init"
             ],
             "cwd": "${workspaceFolder}/tests/test_solution"
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project since 0.82.0 will be documented in this file.
 
+## [2.1.6] - 2020-09-23
+### Changed
+- Fix warning about ConfigParser readfp deprecation
+
 ## [2.1.5] - 2020-08-18
 ### Changed
 - Fix error caused by latest bcrypt on Azure Pipelines agent

--- a/iotedgedev/__init__.py
+++ b/iotedgedev/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'vsciet@microsoft.com'
-__version__ = '2.1.5'
+__version__ = '2.1.6'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'

--- a/iotedgedev/telemetryconfig.py
+++ b/iotedgedev/telemetryconfig.py
@@ -43,7 +43,7 @@ class TelemetryConfig(object):
     @suppress_all_exceptions()
     def load(self):
         with open(self.get_config_path(), 'r') as f:
-            self.config_parser.readfp(f)
+            self.config_parser.read_file(f)
 
     @suppress_all_exceptions()
     def dump(self):

--- a/iotedgedev/telemetryconfig.py
+++ b/iotedgedev/telemetryconfig.py
@@ -43,7 +43,12 @@ class TelemetryConfig(object):
     @suppress_all_exceptions()
     def load(self):
         with open(self.get_config_path(), 'r') as f:
-            self.config_parser.read_file(f)
+            if hasattr(self.config_parser, 'read_file'):
+                self.config_parser.read_file(f)
+            else:  # pragma: no cover
+                assert PY2
+                # The `read_file` method is not available on ConfigParser in py2.7!
+                self.config_parser.readfp(f)
 
     @suppress_all_exceptions()
     def dump(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.5
+current_version = 2.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ test_requirements = [
 
 setup(
     name='iotedgedev',
-    version='2.1.5',
+    version='2.1.6',
     description='The Azure IoT Edge Dev Tool greatly simplifies the IoT Edge development process by automating many routine manual tasks, such as building, deploying, pushing modules and configuring the IoT Edge Runtime.',
     long_description='See https://github.com/azure/iotedgedev for usage instructions.',
     author='Microsoft Corporation',


### PR DESCRIPTION
closes #338 

Replaced readfp with read_file as readfp is being deprecated. Ran unit tests and regression tests with no new issues detected.