### PR TITLE
Fix parsing the output of `az iot hub list`

### DIFF
--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -391,7 +391,7 @@ class AzureCli:
                 data = json.loads(out_string)
                 for iot in data:
                     if iot["sku"]["name"] == "F1":
-                        return (iot["name"], iot["resourceGroup"])
+                        return (iot["name"], iot["resourcegroup"])
         return (None, None)
 
     def get_first_iothub(self, resource_group):


### PR DESCRIPTION
`az iot hub list` returns the parameter `resourcegroup` in lowercase.
As https://github.com/Azure/azure-cli/pull/8950/files suggests, this is true since at least 3 Apr 2019.