### PR TITLE
Update setuptools so az cli can be used within the Windows devops pipeline

### DIFF
--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -12,7 +12,7 @@ steps:
   - pwsh: |
       npm i -g iothub-explorer yo generator-azure-iot-edge-module
       az --version
-      "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U setuptools==52.0.0
+      & "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U setuptools==52.0.0
     displayName: "Install IoT Hub explorer, Yeoman and Azure IoT Edge Node.js module generator packages"
 
   - pwsh: |

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -11,6 +11,7 @@ steps:
 
   - pwsh: |
       npm i -g iothub-explorer yo generator-azure-iot-edge-module
+      az --version
     displayName: "Install IoT Hub explorer, Yeoman and Azure IoT Edge Node.js module generator packages"
 
   - pwsh: |

--- a/vsts_ci/win32/continuous-build-win32.yml
+++ b/vsts_ci/win32/continuous-build-win32.yml
@@ -12,6 +12,7 @@ steps:
   - pwsh: |
       npm i -g iothub-explorer yo generator-azure-iot-edge-module
       az --version
+      "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U setuptools==52.0.0
     displayName: "Install IoT Hub explorer, Yeoman and Azure IoT Edge Node.js module generator packages"
 
   - pwsh: |


### PR DESCRIPTION
This is a work around an az cli issue. All iotedgedev pipelines pass with this fix.