### PR TITLE
baseline az-cli version

### DIFF
--- a/iotedgedev/__init__.py
+++ b/iotedgedev/__init__.py
@@ -2,5 +2,5 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'opencode@microsoft.com'
-__version__ = '3.1.1rc0'
+__version__ = '3.1.1'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'

--- a/iotedgedev/__init__.py
+++ b/iotedgedev/__init__.py
@@ -2,5 +2,5 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'opencode@microsoft.com'
-__version__ = '3.1.0'
+__version__ = '3.1.1rc0'
 __AIkey__ = '95b20d64-f54f-4de3-8ad5-165a75a6c6fe'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,6 @@ python-dotenv
 requests
 fstrings
 msrestazure~=0.4.32
-azure-cli-iot
-azure-cli-profile
-azure-cli-extension
-azure-cli-configure
-azure-cli-resource
-azure-cli-cloud
 iotedgehubdev >= 0.14.3
 applicationinsights
 commentjson

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1rc0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.1rc0
+current_version = 3.1.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,7 @@ requirements = [
     'python-dotenv',
     'requests >= 2.20.0, <= 2.25.1',
     'fstrings',
-    'azure-cli-core',
-    'azure-cli-iot',
-    'azure-cli-profile',
-    'azure-cli-extension',
-    'azure-cli-configure',
-    'azure-cli-resource',
-    'azure-cli-cloud',
+    'azure-cli-core >= 2.25.0',
     'iotedgehubdev >= 0.14.3',
     'applicationinsights == 0.11.9',
     'commentjson == 0.9.0',
@@ -43,7 +37,7 @@ test_requirements = [
 
 setup(
     name='iotedgedev',
-    version='3.1.0',
+    version='3.1.1',
     description='The Azure IoT Edge Dev Tool greatly simplifies the IoT Edge development process by automating many routine manual tasks, such as building, deploying, pushing modules and configuring the IoT Edge Runtime.',
     long_description='See https://github.com/azure/iotedgedev for usage instructions.',
     author='Microsoft Corporation',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ test_requirements = [
 
 setup(
     name='iotedgedev',
-    version='3.1.1rc0',
+    version='3.1.1',
     description='The Azure IoT Edge Dev Tool greatly simplifies the IoT Edge development process by automating many routine manual tasks, such as building, deploying, pushing modules and configuring the IoT Edge Runtime.',
     long_description='See https://github.com/azure/iotedgedev for usage instructions.',
     author='Microsoft Corporation',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ test_requirements = [
 
 setup(
     name='iotedgedev',
-    version='3.1.1',
+    version='3.1.1rc0',
     description='The Azure IoT Edge Dev Tool greatly simplifies the IoT Edge development process by automating many routine manual tasks, such as building, deploying, pushing modules and configuring the IoT Edge Runtime.',
     long_description='See https://github.com/azure/iotedgedev for usage instructions.',
     author='Microsoft Corporation',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'opencode@microsoft.com'
-__version__ = '3.1.0'
+__version__ = '3.1.1rc0'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Microsoft Corporation'
 __email__ = 'opencode@microsoft.com'
-__version__ = '3.1.1rc0'
+__version__ = '3.1.1'


### PR DESCRIPTION
version 3.1.1

- baseline az-cli dependency to 2.25.0 or greater (azure-cli-core)
- remove out of date and unused azure-cli-cloud and other dependencies 