### PR TITLE
Update dotnet docker image refs from dockerhub to mcr

### DIFF
--- a/tests/assets/test_solution_shared_lib/modules/sample_module/Dockerfile.amd64
+++ b/tests/assets/test_solution_shared_lib/modules/sample_module/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 
 COPY ./libs /app/libs
 COPY ./modules/sample_module/*.csproj /app/modules/sample_module/
@@ -8,7 +8,7 @@ WORKDIR /app/modules/sample_module
 RUN dotnet restore
 RUN dotnet publish -c Release -o /app/out
 
-FROM microsoft/dotnet:2.1-runtime-stretch-slim
+FROM mcr.microsoft.com/dotnet/runtime:2.1-stretch-slim
 WORKDIR /app
 COPY --from=build-env /app/out ./
 

--- a/tests/assets/test_solution_shared_lib/modules/sample_module/Dockerfile.amd64.debug
+++ b/tests/assets/test_solution_shared_lib/modules/sample_module/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-runtime-stretch-slim AS base
+FROM mcr.microsoft.com/dotnet/runtime:2.1-stretch-slim AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip procps && \
@@ -8,7 +8,7 @@ RUN useradd -ms /bin/bash moduleuser
 USER moduleuser
 RUN curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l ~/vsdbg
 
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 
 COPY ./libs /app/libs
 COPY ./modules/sample_module/*.csproj /app/modules/sample_module/

--- a/tests/assets/test_solution_shared_lib/modules/sample_module/Dockerfile.windows-amd64
+++ b/tests/assets/test_solution_shared_lib/modules/sample_module/Dockerfile.windows-amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 
 COPY ./libs /app/libs
 COPY ./modules/sample_module/*.csproj /app/modules/sample_module/
@@ -8,7 +8,7 @@ WORKDIR /app/modules/sample_module
 RUN dotnet restore
 RUN dotnet publish -c Release -o /app/out
 
-FROM microsoft/dotnet:2.1-runtime-nanoserver-1803
+FROM mcr.microsoft.com/dotnet/runtime:2.1-nanoserver-1809
 WORKDIR /app
 COPY --from=build-env /app/out ./
 

--- a/tests/assets/test_solution_shared_lib/sample_module_2/Dockerfile.amd64
+++ b/tests/assets/test_solution_shared_lib/sample_module_2/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 
 COPY ./libs /app/libs
 COPY ./sample_module_2/*.csproj /app/sample_module_2/
@@ -8,7 +8,7 @@ WORKDIR /app/sample_module_2
 RUN dotnet restore
 RUN dotnet publish -c Release -o /app/out
 
-FROM microsoft/dotnet:2.1-runtime-stretch-slim
+FROM mcr.microsoft.com/dotnet/runtime:2.1-stretch-slim
 WORKDIR /app
 COPY --from=build-env /app/out ./
 

--- a/tests/assets/test_solution_shared_lib/sample_module_2/Dockerfile.amd64.debug
+++ b/tests/assets/test_solution_shared_lib/sample_module_2/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-runtime-stretch-slim AS base
+FROM mcr.microsoft.com/dotnet/runtime:2.1-stretch-slim AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip procps && \
@@ -8,7 +8,7 @@ RUN useradd -ms /bin/bash moduleuser
 USER moduleuser
 RUN curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l ~/vsdbg
 
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 
 COPY ./libs /app/libs
 COPY ./sample_module_2/*.csproj /app/sample_module_2/

--- a/tests/assets/test_solution_shared_lib/sample_module_2/Dockerfile.windows-amd64
+++ b/tests/assets/test_solution_shared_lib/sample_module_2/Dockerfile.windows-amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 
 COPY ./libs /app/libs
 COPY ./sample_module_2/*.csproj /app/sample_module_2/
@@ -8,7 +8,7 @@ WORKDIR /app/sample_module_2
 RUN dotnet restore
 RUN dotnet publish -c Release -o /app/out
 
-FROM microsoft/dotnet:2.1-runtime-nanoserver-1803
+FROM mcr.microsoft.com/dotnet/runtime:2.1-nanoserver-1809
 WORKDIR /app
 COPY --from=build-env /app/out ./
 


### PR DESCRIPTION
## iotedgedev Pull Request Checklist

- [ ] Versions updated (both __init__.py files, CHANGELOG, setup.py, setup.cfg)
- [x] Unit tests pass locally
- [ ] Quickstart steps locally validated
- [x] Passes unit tests in CICD pipeline (green on Github pipeline)
- [ ] Pypi RC version passes Edge CICD pipeline validation for cross-tool validation

## Additional comments
This failure is blocking CICD for iotedgedev
https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/