### PR TITLE
fix: allow default IoT Hub SKUs (F1)

### DIFF
--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -472,6 +472,7 @@ class AzureCli:
                     # from `az iot hub create --help`:
                     #   The partition count is the number of partitions that the IoT Hub uses to distribute messages.
                     #   The default value is 4.
+                    # In Azure Portal the default and only value is 2.
 
                 result = self.invoke_az_cli_outproc(cmd, f("Could not create the IoT Hub {value} in {resource_group} with sku {sku}."), stdout_io=io, stderr_io=error_io)
                 if not result and error_io.getvalue():

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -467,7 +467,7 @@ class AzureCli:
 
                 cmd = ["iot", "hub", "create", "--name", value, "--resource-group", resource_group, "--sku", sku, "--query", "[].{\"IoT Hub\":name}", "--out", "table"]
                 if sku == "F1":
-                    cmd.append("--partition-count", "2")
+                    cmd = cmd + ["--partition-count", "2"]
 
                 result = self.invoke_az_cli_outproc(cmd, f("Could not create the IoT Hub {value} in {resource_group} with sku {sku}."), stdout_io=io, stderr_io=error_io)
                 if not result and error_io.getvalue():

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -465,9 +465,11 @@ class AzureCli:
                 self.output.prompt(
                     "Creating IoT Hub. Please wait as this could take a few minutes to complete...")
 
-                result = self.invoke_az_cli_outproc(["iot", "hub", "create", "--name", value, "--resource-group",
-                                                     resource_group, "--sku", sku, "--query", "[].{\"IoT Hub\":name}", "--out", "table"],
-                                                    f("Could not create the IoT Hub {value} in {resource_group} with sku {sku}."), stdout_io=io, stderr_io=error_io)
+                cmd = ["iot", "hub", "create", "--name", value, "--resource-group", resource_group, "--sku", sku, "--query", "[].{\"IoT Hub\":name}", "--out", "table"]
+                if sku == "F1":
+                    cmd.append("--partition-count", "2")
+
+                result = self.invoke_az_cli_outproc(cmd, f("Could not create the IoT Hub {value} in {resource_group} with sku {sku}."), stdout_io=io, stderr_io=error_io)
                 if not result and error_io.getvalue():
                     self.output.error(error_io.getvalue())
                     self.output.line()

--- a/iotedgedev/azurecli.py
+++ b/iotedgedev/azurecli.py
@@ -468,6 +468,10 @@ class AzureCli:
                 cmd = ["iot", "hub", "create", "--name", value, "--resource-group", resource_group, "--sku", sku, "--query", "[].{\"IoT Hub\":name}", "--out", "table"]
                 if sku == "F1":
                     cmd = cmd + ["--partition-count", "2"]
+                    # the default partition-count is 4, but F1 allows only 2
+                    # from `az iot hub create --help`:
+                    #   The partition count is the number of partitions that the IoT Hub uses to distribute messages.
+                    #   The default value is 4.
 
                 result = self.invoke_az_cli_outproc(cmd, f("Could not create the IoT Hub {value} in {resource_group} with sku {sku}."), stdout_io=io, stderr_io=error_io)
                 if not result and error_io.getvalue():


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] Versions update reflected in all places (both __init__.py files, CHANGELOG, setup.py, setup.cfg)
- [x] Unit tests pass locally
- [x] Quickstart steps locally validated
- [ ] Passes unit tests in CICD pipeline (green on Github pipeline)
- [ ] Pypi RC version passes Edge CICD pipeline validation for cross-tool validation
- [ ] Pull request includes test coverage for the included changes
- [x] Documentation is updated for the included changes

### General guidelines

- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.

## Description

<!--
Please add a number of a relevant issue below
-->
Fixes #534

Creating a F1 IoT Hu requires setting the partition count to 2. The default from the CLI is 4, so in case F1 is requested the partition count is added to the command.

