### PR TITLE
Deprecate duplicate commands

### DIFF
--- a/iotedgedev/cli.py
+++ b/iotedgedev/cli.py
@@ -3,6 +3,11 @@ import socket
 import sys
 
 import click
+import copy
+import typing as t
+
+from click import Command
+from click import Group
 from fstrings import f
 
 from .azurecli import AzureCli
@@ -18,6 +23,16 @@ from .output import Output
 from .simulator import Simulator
 from .solution import Solution
 from .utility import Utility
+
+# Extend click.Group#add_command(cmd, name) to take deprecated=bool flag by monkey patching.
+def add_command_with_deprecation(self, cmd: Command, name: t.Optional[str] = None, deprecated = False):
+    # Directly changing the deprecated flag of the cmd has side-effects on the reference source.
+    # To avoid this, copy the cmd object with deepcopy.
+    copied_command = copy.deepcopy(cmd)
+    copied_command.deprecated = deprecated
+    self.add_command(copied_command, name)
+
+Group.add_command_with_deprecation = add_command_with_deprecation
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'], max_content_width=120)
 
@@ -84,8 +99,7 @@ def new(name, module, template, edge_runtime_version, group_id):
     sol = Solution(output, utility)
     sol.create(name, module, template, edge_runtime_version, group_id)
 
-
-main.add_command(new)
+main.add_command_with_deprecation(new, deprecated=True)
 
 
 @solution.command(context_settings=CONTEXT_SETTINGS,
@@ -121,7 +135,7 @@ def init(module, template, group_id, edge_runtime_version):
         utility.call_proc(azsetupcmd.split())
 
 
-main.add_command(init)
+main.add_command_with_deprecation(init, deprecated=True)
 
 
 @solution.command(context_settings=CONTEXT_SETTINGS, help="Push, deploy, start, monitor")
@@ -144,7 +158,7 @@ def add(name, template, group_id):
     mod.add(name, template, group_id)
 
 
-main.add_command(add)
+main.add_command_with_deprecation(add, deprecated=True)
 
 
 @solution.command(context_settings=CONTEXT_SETTINGS, help="Build the solution")
@@ -186,7 +200,7 @@ def build(ctx, push, do_deploy, template_file, platform):
         ctx.invoke(deploy)
 
 
-main.add_command(build)
+main.add_command_with_deprecation(build, deprecated=True)
 
 
 @solution.command(context_settings=CONTEXT_SETTINGS, help="Push module images to container registry")
@@ -227,7 +241,7 @@ def push(ctx, do_deploy, no_build, template_file, platform):
         ctx.invoke(deploy)
 
 
-main.add_command(push)
+main.add_command_with_deprecation(push, deprecated=True)
 
 
 @solution.command(context_settings=CONTEXT_SETTINGS, help="Deploy solution to IoT Edge device")
@@ -245,7 +259,7 @@ def deploy(manifest_file):
     edge.deploy(manifest_file)
 
 
-main.add_command(deploy)
+main.add_command_with_deprecation(deploy, deprecated=True)
 
 
 @iothub.command(
@@ -340,7 +354,7 @@ def genconfig(template_file, platform, fail_on_validation_error):
     mod.build_push(template_file, platform, no_build=True, no_push=True, fail_on_validation_error=fail_on_validation_error)
 
 
-main.add_command(genconfig)
+main.add_command_with_deprecation(genconfig, deprecated=True)
 
 
 @simulator.command(context_settings=CONTEXT_SETTINGS,
@@ -363,7 +377,7 @@ def setup_simulator(gateway_host, iothub_connection_string):
     sim.setup(gateway_host, iothub_connection_string)
 
 
-main.add_command(setup_simulator)
+main.add_command_with_deprecation(setup_simulator, deprecated=True)
 
 
 @simulator.command(context_settings=CONTEXT_SETTINGS,
@@ -438,7 +452,7 @@ def start_simulator(setup, solution, build, manifest_file, platform, verbose, in
         sim.start_single(inputs, port)
 
 
-main.add_command(start_simulator)
+main.add_command_with_deprecation(start_simulator, deprecated=True)
 
 
 @simulator.command(context_settings=CONTEXT_SETTINGS,
@@ -450,7 +464,7 @@ def stop_simulator():
     sim.stop()
 
 
-main.add_command(stop_simulator)
+main.add_command_with_deprecation(stop_simulator, deprecated=True)
 
 
 @simulator.command(context_settings=CONTEXT_SETTINGS,
@@ -490,7 +504,7 @@ def monitor(timeout):
     ih.monitor_events(timeout)
 
 
-main.add_command(monitor)
+main.add_command_with_deprecation(monitor, deprecated=True)
 
 
 def ensure_azure_cli_iot_ext():
@@ -824,7 +838,7 @@ def log(show, save):
     dock.handle_logs_cmd(show, save)
 
 
-main.add_command(log)
+main.add_command_with_deprecation(log, deprecated=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Checklist

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] Versions update reflected in all places (both __init__.py files, CHANGELOG, setup.py, setup.cfg)
- [ ] Unit tests pass locally
- [ ] Quickstart steps locally validated
- [ ] Passes unit tests in CICD pipeline (green on Github pipeline)
- [ ] Pypi RC version passes Edge CICD pipeline validation for cross-tool validation
- [ ] Pull request includes test coverage for the included changes
- [ ] Documentation is updated for the included changes

### General guidelines

- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.

## Description

Some commands can be called in two different ways (for instance,
`iotedgedev init` and `iotedgev solution init`). Eventually, this
duplication should be removed to simplify the tool. This is a breaking
change, though; so before implementing it in the next major release, we
should add a deprecation notice in such commands. This deprecation
notice should be added to the help message and printed when the command
is run. This can be done by setting `deprecated=True` in the
`click.Command()` decorator (see
[documentation](https://click.palletsprojects.com/en/8.1.x/api/#click.Command)).

Note that the reason for this duplication is that the commands are added
to two `click` groups (`main` and `solution`). The commands that should be
deprecated are the ones corresponding to the `main` group.

Fixes #559

<!--
Please add an informative description that covers that changes made by the pull request.
-->

### Additional information

<!--
Please add any additional information you have about the PR, such as relevant links.
-->